### PR TITLE
Feature quiet mode

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -70,6 +70,7 @@ class Jettywrapper
     # @param [Symbol] :java_opts A list of options to pass to the jvm 
     def configure(params = {})
       hydra_server = self.instance
+      hydra_server.reset_process!
       hydra_server.quiet = params[:quiet].nil? ? true : params[:quiet]
       if defined?(Rails.root)
        base_path = Rails.root
@@ -247,8 +248,7 @@ class Jettywrapper
        end
      end
      Dir.chdir(@jetty_home) do
-       process = build_process
-       @pid = process.pid
+       process.start
      end
      FileUtils.makedirs(pid_dir) unless File.directory?(pid_dir)
      begin
@@ -256,22 +256,29 @@ class Jettywrapper
      rescue Errno::ENOENT, Errno::EACCES
        f = File.new(File.join(@base_path,'tmp',pid_file),"w")
      end
-     f.puts "#{@pid}"
+     f.puts "#{process.pid}"
      f.close
-     logger.debug "Wrote pid file to #{pid_path} with value #{@pid}"
+     logger.debug "Wrote pid file to #{pid_path} with value #{process.pid}"
    end
  
-   def build_process
-     process = ChildProcess.build(jetty_command)
-     if self.quiet
-       process.io.stderr = File.open("jettywrapper.log", "w+")
-       process.io.stdout = process.io.stderr
-       logger.warn "Logging jettywrapper stdout to #{File.expand_path(process.io.stderr.path)}"
-     else
-       process.io.inherit!
-     end
-     process.detach = true
-     process.start
+   def process
+     @process ||= begin
+        process = ChildProcess.build(jetty_command)
+        if self.quiet
+          process.io.stderr = File.open("jettywrapper.log", "w+")
+          process.io.stdout = process.io.stderr
+           logger.warn "Logging jettywrapper stdout to #{File.expand_path(process.io.stderr.path)}"
+        else
+          process.io.inherit!
+        end
+        process.detach = true
+
+        process
+      end
+   end
+
+   def reset_process!
+     @process = nil
    end
    # Instance stop method. Must be called on Jettywrapper.instance
    # You're probably better off using Jettywrapper.stop(:jetty_home => "/path/to/jetty")
@@ -285,6 +292,7 @@ class Jettywrapper
        process = ChildProcess.new
        process.instance_variable_set(:@pid, pid)
        process.instance_variable_set(:@started, true)
+
        process.stop 
        begin
          File.delete(pid_path)

--- a/spec/lib/jettywrapper_integration_spec.rb
+++ b/spec/lib/jettywrapper_integration_spec.rb
@@ -76,9 +76,7 @@ module Hydra
         lambda{ ts.start }.should raise_exception
         ts.stop
       end
-      
-      
+
     end
-    
   end
 end

--- a/spec/lib/jettywrapper_spec.rb
+++ b/spec/lib/jettywrapper_spec.rb
@@ -73,7 +73,7 @@ module Hydra
           :jetty_home => '/tmp'
         }
         ts = Jettywrapper.configure(jetty_params) 
-        Jettywrapper.any_instance.stubs(:build_process).returns(stub('proc', :pid=>5454))
+        Jettywrapper.any_instance.stubs(:process).returns(stub('proc', :start => nil, :pid=>5454))
         ts.stop
         ts.start
         ts.pid.should eql(5454)
@@ -86,7 +86,7 @@ module Hydra
         }
         ts = Jettywrapper.configure(jetty_params) 
         ts.stop
-        Jettywrapper.any_instance.stubs(:build_process).returns(stub('proc', :pid=>2323))
+        Jettywrapper.any_instance.stubs(:process).returns(stub('proc', :start => nil, :pid=>2323))
         swp = Jettywrapper.start(jetty_params)
         swp.pid.should eql(2323)
         swp.pid_file.should eql("_tmp.pid")
@@ -100,7 +100,7 @@ module Hydra
       # return true if it's running, otherwise return false
       it "can get the status for a given jetty instance" do
         # Don't actually start jetty, just fake it
-        Jettywrapper.any_instance.stubs(:build_process).returns(stub('proc', :pid=>12345))
+        Jettywrapper.any_instance.stubs(:process).returns(stub('proc', :start => nil, :pid=>12345))
         
         jetty_params = {
           :jetty_home => File.expand_path("#{File.dirname(__FILE__)}/../../jetty")
@@ -114,7 +114,7 @@ module Hydra
       
       it "can get the pid for a given jetty instance" do
         # Don't actually start jetty, just fake it
-        Jettywrapper.any_instance.stubs(:build_process).returns(stub('proc', :pid=>54321))
+        Jettywrapper.any_instance.stubs(:process).returns(stub('proc', :start => nil, :pid=>54321))
         jetty_params = {
           :jetty_home => File.expand_path("#{File.dirname(__FILE__)}/../../jetty")
         }
@@ -129,7 +129,7 @@ module Hydra
         jetty_params = {
           :jetty_home => '/tmp', :jetty_port => 8777
         }
-        Jettywrapper.any_instance.stubs(:build_process).returns(stub('proc', :pid=>2323))
+        Jettywrapper.any_instance.stubs(:process).returns(stub('proc', :start => nil, :pid=>2323))
         swp = Jettywrapper.start(jetty_params)
         (File.file? swp.pid_path).should eql(true)
         
@@ -152,7 +152,7 @@ module Hydra
           :jetty_home => '/tmp'
         }
         ts = Jettywrapper.configure(jetty_params) 
-        Jettywrapper.any_instance.stubs(:build_process).returns(stub('proc', :pid=>2222))
+        Jettywrapper.any_instance.stubs(:process).returns(stub('proc', :start => nil, :pid=>2222))
         ts.stop
         ts.pid_file?.should eql(false)
         ts.start
@@ -206,5 +206,21 @@ module Hydra
       end
       
     end # end of wrapping context
+
+    context "quiet mode", :quiet => true do
+      it "inherits the current stderr/stdout in 'loud' mode" do
+        ts = Jettywrapper.configure(@jetty_params.merge(:quiet => false))
+        process = ts.process
+        process.io.stderr.should == $stderr
+        process.io.stdout.should == $stdout
+      end
+
+      it "redirect stderr/stdout to a log file in quiet mode" do
+        ts = Jettywrapper.configure(@jetty_params.merge(:quiet => true))
+        process = ts.process
+        process.io.stderr.should_not == $stderr
+        process.io.stdout.should_not == $stdout
+      end
+    end
   end
 end


### PR DESCRIPTION
I've re-added the quiet mode feature, which got dropped somewhere along the line. I've set it up to log into ./jetty/jettywrapper.log (though I'm, of course, very open to alternate locations).

In the process, to make it test-able, I had to re-arrange Jettywrapper.build_process into a 'memoized' Jettywrapper.process. I think it's for the better anyway.

This pull request is split over two commits, the first just adds the quiet mode back, the second is the re-architecture. Feel free to take one or both.

Thanks
