### PR TITLE
issue #6: support different jetty configuration

### DIFF
--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -1,5 +1,5 @@
-jetty_port: 8983
-java_opts:
-  - "-XX:MaxPermSize=128m" 
-  - "-Xmx256m"
-
+default:
+  jetty_port: 8983
+  java_opts:
+    - "-XX:MaxPermSize=128m" 
+    - "-Xmx256m"

--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -56,7 +56,8 @@ class Jettywrapper
         file ||= YAML.load_file(File.join(File.dirname(__FILE__),"../config/jetty.yml"))
         #raise "Unable to load: #{file}" unless file
       end
-      file.with_indifferent_access
+      config = file.with_indifferent_access
+      config[config_name] || config[:default]
     end
     
 


### PR DESCRIPTION
..by loading the jetty.yml config wrt the current environment (or falling back on the jettywrapper default config)

The current jetty.yml is a single set of configuration for all environments, but one common use case is different configurations in development vs production. This patch adds an environment hierarchy to jetty.yml (with fallback to a 'default' key)
