### PR TITLE
Passing jetty_opts in start command

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -24,6 +24,8 @@ class Jettywrapper
   attr_accessor :base_path    # The root of the application. Used for determining where log files and PID files should go.
   attr_accessor :java_opts    # Options to pass to java (ex. ["-Xmx512mb", "-Xms128mb"])
   attr_accessor :port         # The port jetty should listen on
+
+  attr_accessor :jetty_opts   # Options to pass to jetty (ex. ["etc/my_jetty.xml", "etc/other.xml"] as in http://wiki.eclipse.org/Jetty/Reference/jetty.xml_usage
   
   # configure the singleton with some defaults
   def initialize(params = {})
@@ -86,6 +88,7 @@ class Jettywrapper
       jetty_server.port = params[:jetty_port] || 8888
       jetty_server.startup_wait = params[:startup_wait] || 5
       jetty_server.java_opts = params[:java_opts] || []
+      jetty_server.jetty_opts = params[:jetty_opts] || []
       return jetty_server
     end
    
@@ -100,7 +103,8 @@ class Jettywrapper
     #       :jetty_home => "/path/to/jetty", 
     #       :quiet => false, 
     #       :jetty_port => 8983, 
-    #       :startup_wait => 30
+    #       :startup_wait => 30,
+    #       :jetty_opts => "/etc/jetty.xml"
     #     }
     #     error = Jettywrapper.wrap(jetty_params) do   
     #       Rake::Task["rake:spec"].invoke 
@@ -211,7 +215,7 @@ class Jettywrapper
         
    # What command is being run to invoke jetty? 
    def jetty_command
-     ["java", java_variables, java_opts, "-jar", "start.jar"].flatten
+     ["java", java_variables, java_opts, "-jar", "start.jar", jetty_opts].flatten
    end
 
    def java_variables

--- a/spec/lib/jettywrapper_spec.rb
+++ b/spec/lib/jettywrapper_spec.rb
@@ -12,7 +12,8 @@ require 'rubygems'
         :jetty_port => 8888,
         :solr_home => "/path/to/solr",
         :startup_wait => 0,
-        :java_opts => ["-Xmx256mb"]
+        :java_opts => ["-Xmx256mb"],
+        :jetty_opts => ["/path/to/jetty_xml", "/path/to/other_jetty_xml"]  
       }
     end
 
@@ -57,6 +58,7 @@ require 'rubygems'
         ts.port.should == 8888
         ts.solr_home.should == '/path/to/solr'
         ts.startup_wait.should == 0
+        ts.jetty_opts.should == @jetty_params[:jetty_opts]
       end
 
       # passing in a hash is no longer optional
@@ -70,7 +72,8 @@ require 'rubygems'
           :jetty_home => '/path/to/jetty',
           :jetty_port => nil,
           :solr_home => nil,
-          :startup_wait => nil
+          :startup_wait => nil,
+          :jetty_opts => nil
         }
 
         ts = Jettywrapper.configure(jetty_params) 
@@ -79,6 +82,7 @@ require 'rubygems'
         ts.port.should == 8888
         ts.solr_home.should == File.join(ts.jetty_home, "solr")
         ts.startup_wait.should == 5
+        ts.jetty_opts.should == []
       end
       
       it "passes all the expected values to jetty during startup" do
@@ -87,6 +91,8 @@ require 'rubygems'
         command.should include("-Dsolr.solr.home=#{@jetty_params[:solr_home]}")
         command.should include("-Djetty.port=#{@jetty_params[:jetty_port]}")
         command.should include("-Xmx256mb")
+        command.should include("start.jar")
+        command.slice(command.index('start.jar')+1, 2).should == @jetty_params[:jetty_opts]
       end
 
       it "escapes the :solr_home parameter" do
@@ -217,7 +223,7 @@ require 'rubygems'
           ts.jetty_home.should == "/path/to/jetty"
           ts.port.should == 8888
           ts.solr_home.should == "/path/to/solr"
-          ts.startup_wait.should == 0     
+          ts.startup_wait.should == 0   
         end
         error.should eql(false)
       end


### PR DESCRIPTION
Appending a new configuration parameter for jetty. 

Example:

If params = {
  :solr_home => '/var/solr',
  :jetty_opts => '/etc/jetty.xml'
}, then this is how a jetty command should look like after merging with the default configuration: 

java  -XX:MaxPermSize=128m -Xmx256m  -Djetty.port=8888 -Dsolr.solr.home=/var/solr -jar start.jar /etc/jetty.xml

See http://wiki.eclipse.org/Jetty/Reference/jetty.xml_usage.

Thanks,

Renzo
