### PR TITLE
Throw error on start if port already in use

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -274,9 +274,9 @@ class Jettywrapper
          logger.warn "Removing stale PID file at #{pid_path}"
          File.delete(pid_path)
        end
-       if Jettywrapper.is_port_in_use?(self.port)
-         raise("Port #{self.port} is already in use.")
-       end
+     end
+     if Jettywrapper.is_port_in_use?(self.port)
+       raise("Port #{self.port} is already in use.")
      end
      Dir.chdir(@jetty_home) do
        process.start

--- a/spec/lib/jettywrapper_integration_spec.rb
+++ b/spec/lib/jettywrapper_integration_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'rubygems'
 require 'uri'
 require 'net/http'
+require 'socket'
 
 module Hydra
   describe Jettywrapper do    
@@ -77,6 +78,24 @@ module Hydra
         ts.start
         lambda{ ts.start }.should raise_exception
         ts.stop
+      end
+
+      it "raises an error if you try to start a jetty when the port is already in use" do
+        jetty_params = {
+          :jetty_home => File.expand_path("#{File.dirname(__FILE__)}/../../jetty"),
+          :jetty_port => TEST_JETTY_PORTS.first,
+          :startup_wait => 30
+        }
+	socket = TCPServer.new(TEST_JETTY_PORTS.first)
+        begin
+          ts = Jettywrapper.configure(jetty_params) 
+          ts.stop
+          ts.pid_file?.should eql(false)
+          lambda{ ts.start }.should raise_exception
+          ts.stop
+        ensure
+          socket.close
+        end
       end
 
     end


### PR DESCRIPTION
The code to handle this case was hidden inside the check to see if the jetty instance was already running.  I moved it out and added a test.
