### PR TITLE
Use the instance variable 'url' rather than the local variable

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -69,7 +69,7 @@ class Jettywrapper
       logger.info "Downloading jetty at #{self.url} ..."
       FileUtils.mkdir tmp_dir unless File.exists? tmp_dir
       system "curl -L #{self.url} -o #{zip_file}"
-      abort "Unable to download jetty from #{url}" unless $?.success?
+      abort "Unable to download jetty from #{self.url}" unless $?.success?
     end
     
     def unzip


### PR DESCRIPTION
This message is printing out the local url variable rather than the
instance variable of the same name. That means we sometimes see
errors like this:

```
Unable to download jetty from
```

See #15
