### PR TITLE
Remove existing jetty directory on subsequent calls to unzip

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -79,6 +79,10 @@ class Jettywrapper
       system "unzip -d #{tmp_save_dir} -qo #{zip_file}"
       abort "Unable to unzip #{zip_file} into tmp_save_dir/" unless $?.success?
 
+      # Remove the old jetty directory if it exists
+      system "rm -r #{jetty_dir}" if File.directory?(jetty_dir)
+
+      # Move the expanded zip file into the final destination.
       expanded_dir = expanded_zip_dir(tmp_save_dir)
       system "mv #{expanded_dir} #{jetty_dir}"
       abort "Unable to move #{expanded_dir} into #{jetty_dir}/" unless $?.success?

--- a/spec/lib/jettywrapper_spec.rb
+++ b/spec/lib/jettywrapper_spec.rb
@@ -44,6 +44,7 @@ require 'rubygems'
           File.should_receive(:exists?).and_return(true)
           Jettywrapper.should_receive(:expanded_zip_dir).and_return('tmp/jetty_generator/hydra-jetty-new-solr-schema')
           Jettywrapper.should_receive(:system).with('unzip -d tmp/jetty_generator -qo tmp/new-solr-schema.zip').and_return(system ('true'))
+          Jettywrapper.should_receive(:system).with('rm -r jetty').and_return(system ('true'))
           Jettywrapper.should_receive(:system).with('mv tmp/jetty_generator/hydra-jetty-new-solr-schema jetty').and_return(system ('true'))
           Jettywrapper.unzip
         end
@@ -57,6 +58,7 @@ require 'rubygems'
           File.should_receive(:exists?).and_return(true)
           Jettywrapper.should_receive(:expanded_zip_dir).and_return('tmp/jetty_generator/interal_dir')
           Jettywrapper.should_receive(:system).with('unzip -d tmp/jetty_generator -qo tmp/file.zip').and_return(system ('true'))
+          Jettywrapper.should_receive(:system).with('rm -r jetty').and_return(system ('true'))
           Jettywrapper.should_receive(:system).with('mv tmp/jetty_generator/interal_dir jetty').and_return(system ('true'))
           Jettywrapper.unzip
         end


### PR DESCRIPTION
Otherwise a subsequent call ends up putting the expanded zip directory in `jetty/hydra-jetty-master`
