### PR TITLE
Only load rake tasks if rake DSL is present

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -9,7 +9,7 @@ require 'erb'
 require 'yaml'
 require 'logger'
 
-Dir[File.expand_path(File.join(File.dirname(__FILE__),"tasks/*.rake"))].each { |ext| load ext } if defined?(Rake)
+Dir[File.expand_path(File.join(File.dirname(__FILE__),"tasks/*.rake"))].each { |ext| load ext } if defined?(Rake) && respond_to?(:namespace)
 
 
 # Jettywrapper is a Singleton class, so you can only create one jetty instance at a time.


### PR DESCRIPTION
It's reasonably possible for `Rake` to be defined, but the DSL hasn't been 
included into the global namespace. If this is the case (such as happens 
when RubyMine runs tests within the IDE), then this line will blow up when
jettywrapper gets required. Here we add an extra test to make sure that the
required DSL is in place before we load the tasks.
