### PR TITLE
explicitly adds dependency for benchmarkable

### DIFF
--- a/jettywrapper.gemspec
+++ b/jettywrapper.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess"
   s.add_dependency "i18n"
   s.add_dependency "activesupport", ">=3.0.0"
+  s.add_dependency 'activesupport-core-ext'
   
   s.add_development_dependency "rspec", '~> 2.99'
   s.add_development_dependency "rspec-its"


### PR DESCRIPTION
Closes #30 

This explicitly requires 'activesupport-core-ext' as a dependency. Having issues in other projects where travis will report that Benchmarkable is not loaded.

```
NameError: uninitialized constant ActiveSupport::Benchmarkable
```

https://travis-ci.org/geoblacklight/geoblacklight/builds/45956482