### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,81 @@
 # Jettywrapper [![Version](https://badge.fury.io/gh/projecthydra%2Fjettywrapper.png)](http://badge.fury.io/gh/projecthydra%2Fjettywrapper) [![Build Status](https://travis-ci.org/projecthydra/jettywrapper.png?branch=master)](https://travis-ci.org/projecthydra/jettywrapper)
 
-This gem is designed to make it easier to integrate a jetty servlet container into a rails project.  
-Jettywrapper provides rake tasks for starting and stopping jetty, as well as the method `Jettywrapper.wrap` that will start
-the server before the block and stop the server after the block, which is useful for automated testing.
+This gem is designed to make it easier to integrate a jetty servlet container into a project with web service dependencies.  This can be especially useful for developing and testing projects requiring, for example, a Solr and/or a Fedora server.
 
-By default, Jettywrapper is designed to work with Rails projects that use the Hydra gem, and downloads an instance of a 
-[hydra-jetty](https://github.com/projecthydra/hydra-jetty) project zipfile. However, it can be configured to 
-download any Jetty-based project on Github.
+Jettywrapper provides rake tasks for starting and stopping jetty, as well as the method `Jettywrapper.wrap` that will start the server before the block and stop the server after the block, which is useful for automated testing.
 
-Jettywrapper supports
+Jettywrapper can be configured to work with any Jetty-based zip file, such as [blacklight-jetty](https://github.com/projectblacklight/blacklight-jetty) (Solr only) or [hydra-jetty](https://github.com/projecthydra/hydra-jetty) (Solr + Fedora). Jettywrapper uses hydra-jetty by default.
 
-* ruby 2.0.0
-* ruby 1.9.3 
-* ruby 1.8.7 
-* ree  1.8.7
-* jruby 1.6.6+
+## Requirements
 
-## Configuring Jettywrapper
+1.  ruby -- Jettywrapper supports the ruby versions in its [.travis.yml](.travis.yml) file.
+2.  bundler -- this ruby gem must be installed.
+3.  java -- Jetty is a java based servlet container; the version of java required depends on the version of jetty you are using (in the jetty-based zip file).
 
-Jettywrapper starts the process with a list of options that you can specify in `config/jetty.yml`, otherwise a default is used.
-You can provide a per-environment configuration, or you can have a default configuration which will be used when a per-environment
-configuration is not specified. Such a configuration might look like:
+## Installation
 
-    default:
-      jetty_port: 8983
-      java_opts:
-        - "-XX:MaxPermSize=128m"
-        - "-Xmx256m"
+Generally, you will only use a jetty instance for your project's web service dependencies during development and testing, not for production. So you would add this to your Gemfile:
 
-You can also configure a specific version of hydra-jetty. This is placed in your codebase, usually in a rake task 
+```
+group :development, :test do
+  gem 'jettywrapper'
+end
+```
 
-    Jettywrapper.hydra_jetty_version = "v1.2.3"
+Or, if your project is a gem, you would add this to your .gemspec file:
 
-Alternatively, you can use a completely different Jetty-based repository, Hydra-related or not
+```
+Gem::Specification.new do |s|
+  s.add_development_dependency 'jettywrapper'
+end
+```
 
-    Jettywrapper.url = "https://github.com/myorg/my-jetty/archive/master.zip"
+Then execute:
 
-The name of the zip file can either be a branch name, such as master or develop, or the tag name of a released version.
-Basically, any url that Github provides as a *.zip file will work.
+    $ bundle
 
-## Example rake task
+Or install it yourself as:
+
+    $ gem install jettywrapper
+
+
+## Usage
+
+### Configuration
+
+See [Configuring jettywrapper](https://github.com/projecthydra/jettywrapper/wiki/Configuring-jettywrapper).
+
+If you don't need both Solr and Fedora, we recommend you avoid the default [hydra-jetty](https://github.com/projecthydra/hydra-jetty). If you only need Solr, use [blacklight-jetty](https://github.com/projectblacklight/blacklight-jetty).
+
+### Gotchas
+
+* Jetty may take a while to spin up
+* Jetty may not shut down cleanly
+
+See [Using jettywrapper](https://github.com/projecthydra/jettywrapper/wiki/Using-jettywrapper) for more information and what to do.
+
+### Example Rake Task
+
+See [Using jettywrapper](https://github.com/projecthydra/jettywrapper/wiki/Using-jettywrapper) for more information.
 
 ```ruby
 require 'jettywrapper'
-Jettywrapper.url = "https://github.com/myorg/my-jetty/archive/testing-feature-branch.zip"
-desc "Hudson build"
-task :hudson do
-  jetty_params = Jettywrapper.load_config.merge({:jetty_home => File.expand_path(File.dirname(__FILE__) + '/../jetty')})
-  error = Jettywrapper.wrap(jetty_params) do  
-    Rake::Task["spec"].invoke
+
+desc 'run the tests for continuous integration'
+task ci: ['jetty:clean', 'myproj:configure_jetty'] do
+  ENV['environment'] = 'test'
+  jetty_params = Jettywrapper.load_config
+  jetty_params[:startup_wait] = 60
+
+  error = nil
+  error = Jettywrapper.wrap(jetty_params) do
+    # run the tests
+    Rake::Task['spec'].invoke
   end
   raise "test failures: #{error}" if error
 end
 ```
 
-## Testing the gem 
+## Contributing
 
-If you haven't already, clone the git repository
-
-    git clone git@github.com:projecthydra/jettywrapper.git
-    cd jettywrapper
-
-Install the gems
-
-    bundle install
-
-Run the tests
-
-    rake 
+See [CONTRIBUTING.md](https://github.com/projecthydra/jettywrapper/blob/master/CONTRIBUTING.md) to help us make this project better.


### PR DESCRIPTION
I wrote two wiki pages, one about configuring jettywrapper and the other about using it.

I changed the README to 

* refer to the wiki pages for details on configuration and usage
* have instructions for how to install jettywrapper
* changed the "testing" section to a "contributing" section.