### PR TITLE
Requires jettywrapper in rake file: easier to use Jettywrapper outside of hydra

### DIFF
--- a/lib/tasks/jettywrapper.rake
+++ b/lib/tasks/jettywrapper.rake
@@ -1,5 +1,6 @@
 ## These tasks get loaded into the host application when jettywrapper is required
 require 'yaml'
+require 'jettywrapper'
 
 namespace :jetty do
   JETTY_DIR = 'jetty'


### PR DESCRIPTION
With this small change it is possible to load Jettywrapper's rake tasks into another environment, via a Rakefile with this content:

```ruby
spec = Gem::Specification.find_by_name 'jettywrapper'
load File.expand_path 'lib/tasks/jettywrapper.rake', spec.gem_dir
```

It is then possible to pull down and build a standalone Jetty instance (with solr and fedora) by running these commands within ruby:

```ruby
require 'jettywrapper'
Jettywrapper.unzip
```

And then be able to start and stop the Jetty instance with `rake jetty:start` and `rake jetty:stop`