### PR TITLE
Load rake tasks only if defined?(Rake::VERSION)

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -12,7 +12,7 @@ require 'open-uri'
 require 'tempfile'
 require 'zip'
 
-Dir[File.expand_path(File.join(File.dirname(__FILE__),"tasks/*.rake"))].each { |ext| load ext } if defined?(Rake)
+Dir[File.expand_path(File.join(File.dirname(__FILE__),"tasks/*.rake"))].each { |ext| load ext } if (defined?(Rake::VERSION))
 
 class Jettywrapper
 


### PR DESCRIPTION
In jettywrapper.rb, only load rake tasks if defined?(Rake::VERSION).
Testing only defined?(Rake) is brittle because some code libraries
monkey patch Rake.  If the Rake gem is not loaded, this patching
will nevertheless cause the Rake constant to spring into existence,
and jettywrapper will mistakenly then attempt to load its Rake tasks,
even though the core Rake functionality is absent.

A real-world case of this is the JetBrains TeamCity code that is
automatically loaded when line debugging Ruby code in RubyMine/Intellij.
If the rake gem is not loaded for a given Run/Debug configuration,
the session will error out inside the jettywrapper gem.

Closes #53