### PR TITLE
Use containerized Travis VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 
 matrix:


### PR DESCRIPTION
This should help fix the bundle errors in Travis builds:
```
NoMethodError: undefined method `spec' for nil:NilClass
```

And also run faster.