### PR TITLE
Allow for OpenJDK rather than just Oracle Java

### DIFF
--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -347,8 +347,8 @@ class Jettywrapper
         f.rewind
         err = f.read
 
-        java_version = if version = err.match(/java version "([^"]+)"/)
-          version[1]
+        java_version = if version = err.match(/(java|openjdk) version "([^"]+)"/)
+          version[2]
         else
           raise "Java not found, or an error was encountered when running `#{java_path} -version`: #{err}"
         end


### PR DESCRIPTION
If the output of 'java -version' does not match 'java version <version>', the check_java_version! function fails.  Since the output of 'java -version' with OpenJDK installed is 'openjdk version <version>', allow that as an option.