### PR TITLE
do not require the logger gem

### DIFF
--- a/jettywrapper.gemspec
+++ b/jettywrapper.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "logger"
   s.add_dependency "childprocess"
   s.add_dependency "i18n"
   s.add_dependency "activesupport", ">=3.0.0"


### PR DESCRIPTION
No clear reason for introducing this dependency in modern Ruby.