### PR TITLE
Adding compatibility for OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,5 @@ matrix:
       gemfile: gemfiles/rails4.2.gemfile
     - rvm: 2.0
       gemfile: gemfiles/rails4.2.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails4.1.gemfile
     - rvm: jruby-19mode
       gemfile: gemfiles/rails4.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: ruby
 matrix:
   include:
+    - rvm: 2.2
+      gemfile: gemfiles/rails5.2.gemfile
     - rvm: 2.1
       gemfile: gemfiles/rails4.1.gemfile
     - rvm: 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 matrix:
+  allow_failures:
+    - rvm: jruby-9.1.7.0
   include:
     - rvm: 2.2
       gemfile: gemfiles/rails5.2.gemfile
@@ -10,5 +12,5 @@ matrix:
       gemfile: gemfiles/rails4.2.gemfile
     - rvm: 2.0
       gemfile: gemfiles/rails4.2.gemfile
-    - rvm: jruby-19mode
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails4.2.gemfile

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+file = File.expand_path("../../Gemfile", __FILE__)
+
+if File.exists?(file)
+  puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(file)
+end
+
+gem 'activesupport', '~> 5.2.3'

--- a/lib/jettywrapper.rb
+++ b/lib/jettywrapper.rb
@@ -347,8 +347,8 @@ class Jettywrapper
         f.rewind
         err = f.read
 
-        java_version = if version = err.match(/java version "([^"]+)"/)
-          version[1]
+        java_version = if version = err.match(/(java|openjdk) version "([^"]+)"/)
+          version[2]
         else
           raise "Java not found, or an error was encountered when running `#{java_path} -version`: #{err}"
         end


### PR DESCRIPTION
Running this gem with openjdk8 produces errors because `openjdk8 -version` returns `openjdk version XXX` instead of `java version XXX`. Changing regex for version check to allow first word to be java or openjdk.

Removing testing support for Ruby 1.9.3 and adding JRuby to the list of allowed failures.

